### PR TITLE
[JSFIX] Major version upgrade of uuid from version N/A to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "uuid": "^7.0.3"
+    "uuid": "^8.0.0"
   },
   "peerDependencies": {
     "xstate": "^4.9.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10281,10 +10281,10 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
This pull request was created by [mR4smussen](https://github.com/mR4smussen) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades uuid to version 8.0.0.

The JSFIX tool used advanced program analysis to determine how uuid is used by vue-xstate and how it is affected by breaking changes in uuid version 8.0.0 (see details below). JSFIX checked for the 2 breaking changes affecting uuid version 8.0.0 and found 0 occurrences in vue-xstate. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package updates from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* For native ECMAScript Module (ESM) usage in Node.js only named exports are exposed, there is no more default export.
* Deep requiring specific algorithms of this library like require('uuid/v4'), which has been deprecated in uuid@7, is no longer supported.
</details>



***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.